### PR TITLE
Fix code scanning alert no. 1: Clear text storage of sensitive information

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.2",
-    "react-simple-image-slider": "^1.0.4"
+    "react-simple-image-slider": "^1.0.4",
+    "crypto-js": "^4.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/Screens/LogIn/LogIn.jsx
+++ b/src/Screens/LogIn/LogIn.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Redirect } from "react-router-dom";
 import "./LogIn.css";
+import CryptoJS from "crypto-js";
 
 export default function Login({ setLoggedInUser }) {
   const [values, setValues] = useState({
@@ -12,6 +13,15 @@ export default function Login({ setLoggedInUser }) {
     firstTimePassword: "",
     firstTimePassword2: "",
   });
+
+  const encryptPassword = (password) => {
+    return CryptoJS.AES.encrypt(password, 'secret key 123').toString();
+  };
+
+  const decryptPassword = (ciphertext) => {
+    const bytes = CryptoJS.AES.decrypt(ciphertext, 'secret key 123');
+    return bytes.toString(CryptoJS.enc.Utf8);
+  };
 
   const [errors, setErrors] = useState({});
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -47,7 +57,7 @@ export default function Login({ setLoggedInUser }) {
         JSON.stringify({
           firstname: values.firstname,
           lastname: values.lastname,
-          password: values.firstTimePassword,
+          password: encryptPassword(values.firstTimePassword),
         })
       );
       setIsSubmitted(true);
@@ -62,7 +72,7 @@ export default function Login({ setLoggedInUser }) {
     const storedUser = localStorage.getItem(values.username);
     if (storedUser) {
       const userData = JSON.parse(storedUser);
-      if (userData.password === values.password) {
+      if (decryptPassword(userData.password) === values.password) {
         setLoggedInUser(values.username);
         setIsSignedIn(true);
       } else {


### PR DESCRIPTION
Fixes [https://github.com/Darnycya/Escape-NYC/security/code-scanning/1](https://github.com/Darnycya/Escape-NYC/security/code-scanning/1)

To fix the problem, we need to ensure that the passwords are encrypted before being stored in localStorage. We can use the `crypto-js` library to handle encryption and decryption. This will involve:
1. Importing the `crypto-js` library.
2. Creating functions to encrypt and decrypt the passwords.
3. Encrypting the password before storing it in localStorage.
4. Decrypting the password when retrieving it from localStorage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
